### PR TITLE
Fix utlfixedmemory on x64

### DIFF
--- a/public/tier1/utlfixedmemory.h
+++ b/public/tier1/utlfixedmemory.h
@@ -45,11 +45,11 @@ class CUtlFixedMemory
 {
 public:
 	// constructor, destructor
-	CUtlFixedMemory( int nGrowSize = 0, int nInitSize = 0 );
+	CUtlFixedMemory( intp nGrowSize = 0, intp nInitSize = 0 );
 	~CUtlFixedMemory();
 
 	// Set the size by which the memory grows
-	void Init( int nGrowSize = 0, int nInitSize = 0 );
+	void Init( intp nGrowSize = 0, intp nInitSize = 0 );
 
 	// here to match CUtlMemory, but only used by ResetDbgInfo, so it can just return NULL
 	T* Base() { return NULL; }
@@ -62,7 +62,7 @@ public:
 	class Iterator_t
 	{
 	public:
-		Iterator_t( BlockHeader_t *p, int i ) : m_pBlockHeader( p ), m_nIndex( i ) {}
+		Iterator_t( BlockHeader_t *p, intp i ) : m_pBlockHeader( p ), m_nIndex( i ) {}
 		BlockHeader_t *m_pBlockHeader;
 		intp m_nIndex;
 
@@ -127,10 +127,10 @@ public:
 	int Count() const { return NumAllocated(); }
 
 	// Grows memory by max(num,growsize), and returns the allocation index/ptr
-	void Grow( int num = 1 );
+	void Grow( intp num = 1 );
 
 	// Makes sure we've got at least this much memory
-	void EnsureCapacity( int num );
+	void EnsureCapacity( intp num );
 
 	// Memory deallocation
 	void Purge();
@@ -156,8 +156,8 @@ protected:
 	const BlockHeader_t *BlockToHeader( const T *pBlock ) const { return ( BlockHeader_t* )( pBlock ) - 1; }
 
 	BlockHeader_t* m_pBlocks;
-	int m_nAllocationCount;
-	int m_nGrowSize;
+	intp m_nAllocationCount;
+	intp m_nGrowSize;
 };
 
 //-----------------------------------------------------------------------------
@@ -165,7 +165,7 @@ protected:
 //-----------------------------------------------------------------------------
 
 template< class T >
-CUtlFixedMemory<T>::CUtlFixedMemory( int nGrowSize, int nInitAllocationCount )
+CUtlFixedMemory<T>::CUtlFixedMemory( intp nGrowSize, intp nInitAllocationCount )
 : m_pBlocks( 0 ), m_nAllocationCount( 0 ), m_nGrowSize( 0 )
 {
 	Init( nGrowSize, nInitAllocationCount );
@@ -194,7 +194,7 @@ void CUtlFixedMemory<T>::Swap( CUtlFixedMemory< T > &mem )
 // Set the size by which the memory grows - round up to the next power of 2
 //-----------------------------------------------------------------------------
 template< class T >
-void CUtlFixedMemory<T>::Init( int nGrowSize /* = 0 */, int nInitSize /* = 0 */ )
+void CUtlFixedMemory<T>::Init( intp nGrowSize /* = 0 */, intp nInitSize /* = 0 */ )
 {
 	Purge();
 
@@ -264,12 +264,12 @@ inline bool CUtlFixedMemory<T>::IsIdxValid( intp i ) const
 }
 
 template< class T >
-void CUtlFixedMemory<T>::Grow( int num )
+void CUtlFixedMemory<T>::Grow( intp num )
 {
 	if ( num <= 0 )
 		return;
 
-	int nBlockSize = m_nGrowSize;
+	intp nBlockSize = m_nGrowSize;
 	if ( nBlockSize == 0 )
 	{
 		if ( m_nAllocationCount )
@@ -285,7 +285,7 @@ void CUtlFixedMemory<T>::Grow( int num )
 	}
 	if ( nBlockSize < num )
 	{
-		int n = ( num + nBlockSize -1 ) / nBlockSize;
+		intp n = ( num + nBlockSize -1 ) / nBlockSize;
 		Assert( n * nBlockSize >= num );
 		Assert( ( n - 1 ) * nBlockSize < num );
 		nBlockSize *= n;
@@ -326,7 +326,7 @@ void CUtlFixedMemory<T>::Grow( int num )
 // Makes sure we've got at least this much memory
 //-----------------------------------------------------------------------------
 template< class T >
-inline void CUtlFixedMemory<T>::EnsureCapacity( int num )
+inline void CUtlFixedMemory<T>::EnsureCapacity( intp num )
 {
 	Grow( num - NumAllocated() );
 }

--- a/public/tier1/utllinkedlist.h
+++ b/public/tier1/utllinkedlist.h
@@ -385,14 +385,14 @@ private:
 
 // this is kind of ugly, but until C++ gets templatized typedefs in C++0x, it's our only choice
 template < class T >
-class CUtlFixedLinkedList : public CUtlLinkedList< T, int, true, int, CUtlFixedMemory< UtlLinkedListElem_t< T, int > > >
+class CUtlFixedLinkedList : public CUtlLinkedList< T, intp, true, intp, CUtlFixedMemory< UtlLinkedListElem_t< T, intp > > >
 {
 public:
 	CUtlFixedLinkedList( int growSize = 0, int initSize = 0 )
-		: CUtlLinkedList< T, int, true, int, CUtlFixedMemory< UtlLinkedListElem_t< T, int > > >( growSize, initSize ) {}
+		: CUtlLinkedList< T, intp, true, intp, CUtlFixedMemory< UtlLinkedListElem_t< T, intp > > >( growSize, initSize ) {}
 
-	typedef CUtlLinkedList< T, int, true, int, CUtlFixedMemory< UtlLinkedListElem_t< T, int > > > BaseClass;
-	bool IsValidIndex( int i ) const
+	typedef CUtlLinkedList< T, intp, true, intp, CUtlFixedMemory< UtlLinkedListElem_t< T, intp > > > BaseClass;
+	bool IsValidIndex( intp i ) const
 	{
 		if ( !BaseClass::Memory().IsIdxValid( i ) )
 			return false;
@@ -409,7 +409,7 @@ public:
 	}
 
 private:
-	int	MaxElementIndex() const { Assert( 0 ); return BaseClass::InvalidIndex(); } // fixedmemory containers don't support iteration from 0..maxelements-1
+	intp	MaxElementIndex() const { Assert( 0 ); return BaseClass::InvalidIndex(); } // fixedmemory containers don't support iteration from 0..maxelements-1
 	void ResetDbgInfo() {}
 };
 
@@ -434,7 +434,7 @@ CUtlLinkedList<T,S,ML,I,M>::CUtlLinkedList( int growSize, int initSize ) :
 	m_Memory( growSize, initSize ), m_LastAlloc( m_Memory.InvalidIterator() )
 {
 	// Prevent signed non-int datatypes
-	COMPILE_TIME_ASSERT( sizeof(S) == 4 || ( ( (S)-1 ) > 0 ) );
+	COMPILE_TIME_ASSERT( sizeof(S) == 8 || sizeof(S) == 4 || ( ( (S)-1 ) > 0 ) );
 	ConstructList();
 	ResetDbgInfo();
 }

--- a/public/tier1/utlrbtree.h
+++ b/public/tier1/utlrbtree.h
@@ -318,7 +318,7 @@ protected:
 };
 
 // this is kind of ugly, but until C++ gets templatized typedefs in C++0x, it's our only choice
-template < class T, class I = int, typename L = bool (*)( const T &, const T & )  >
+template < class T, class I = intp, typename L = bool (*)( const T &, const T & )  >
 class CUtlFixedRBTree : public CUtlRBTree< T, I, L, CUtlFixedMemory< UtlRBTreeNode_t< T, I > > >
 {
 public:


### PR DESCRIPTION
Fix CUtlFixedMemory and related containers to work on 64 bit systems. Replace int with intp (pointer size integer), just like it was done in on tf2 x64 build